### PR TITLE
Monero: Release funds after 3 confirmations + [discussion] transfer > transfer_split

### DIFF
--- a/bin/basicswap_prepare.py
+++ b/bin/basicswap_prepare.py
@@ -1550,7 +1550,7 @@ def main():
             'datadir': os.getenv('XMR_DATA_DIR', os.path.join(data_dir, 'monero')),
             'bindir': os.path.join(bin_dir, 'monero'),
             'restore_height': xmr_restore_height,
-            'blocks_confirmed': 7,  # TODO: 10?
+            'blocks_confirmed': 3,
         },
         'pivx': {
             'connection_type': 'rpc' if 'pivx' in with_coins else 'none',


### PR DESCRIPTION
1. using `transfer_split` instead of `transfer`.
please confirm changes were done correctly before merge 
https://www.getmonero.org/resources/developer-guides/wallet-rpc.html#transfer_split
related but doesn't close: https://github.com/tecnovert/basicswap/issues/2
2. I assume "blocks_confirned" to be "wait x blocks before spendable". If so, monero is 10. (changed from 7)


edit: `blocks_confirmed` is in regards to transaction finality - when to release. In this case, 7 seems excessive. Changed to 3.
for comparison, litecoin is 2 (5min). Monero was 7 (14mins). Changing to 3 = 6mins