### PR TITLE
monero: auto fee bypass to normal until fixed upstream

### DIFF
--- a/basicswap/interface/xmr.py
+++ b/basicswap/interface/xmr.py
@@ -83,7 +83,7 @@ class XMRInterface(CoinInterface):
 
         self.blocks_confirmed = coin_settings['blocks_confirmed']
         self._restore_height = coin_settings.get('restore_height', 0)
-        self.setFeePriority(coin_settings.get('fee_priority', 0))
+        self.setFeePriority(coin_settings.get('fee_priority', 2))
         self._sc = swap_client
         self._log = self._sc.log if self._sc and self._sc.log else logging
         self._wallet_password = None

--- a/basicswap/templates/offers.html
+++ b/basicswap/templates/offers.html
@@ -844,7 +844,7 @@ const chart = new Chart(ctx, {
                             </div>
                             <!-- RECIPIENT -->
 
-                            <!-- YOUR REQUESTING / TAKER / NOBOOK -->
+                            <!-- YOU REQUESTING FROM TAKER / NOBOOK -->
                             {% if o[9] == true %}
                             <td class="py-3 px-2 text-xs hidden">
                                 <div class="flex items-center">
@@ -864,7 +864,7 @@ const chart = new Chart(ctx, {
                                     </div>
                                 </div>
                             </td>
-                            <!-- YOU REQUESTING / TAKER / NOBOOK -->
+                            <!-- YOU REQUESTING FROM TAKER / NOBOOK -->
 
                             <!-- OFFERS WHERE YOU WILL BE TAKER -->
                             {% else %}
@@ -913,7 +913,7 @@ const chart = new Chart(ctx, {
                                         <a data-tooltip-target="tooltip-maker{{loop.index}}" href="/offer/{{ o[1] }}">
 
                                     <div class="flex flex-col text-sm ml-5">
-                                        <div class="coinname bold text-left w-24" data-coinname="{{ o[2] }}">
+                                        <div class="coinname bold text-right w-24" data-coinname="{{ o[2] }}">
                                             {{ o[4]|truncate(7, true, '', 0) }}
                                         </div>
                                         {{ o[2] }}
@@ -963,7 +963,7 @@ const chart = new Chart(ctx, {
                                         <a data-tooltip-target="tooltip-offer{{loop.index}}" href="/offer/{{ o[1] }}">
 
                                           <div class="flex flex-col text-sm ml-5">
-                                              <div class="coinname bold text-left w-24" data-coinname="{{ o[2] }}">
+                                              <div class="coinname bold text-right w-24" data-coinname="{{ o[2] }}">
                                                   {{ o[4]|truncate(7, true, '', 0) }}
                                               </div>
                                               {{ o[2] }}
@@ -988,21 +988,21 @@ const chart = new Chart(ctx, {
                             <!-- NETWORK OFFERS / MAKER / BOOK -->
 
                             <!-- RATE -->
-                            <td class="py-3 px-2 text-xs text-left items-center rate-table-info">
+                            <td class="py-3 px-2 bold monospace italic text-sm text-left items-center rate-table-info">
                                 <span class="profit-value hidden"></span>
                                 <div class="coinname-value hidden" data-coinname="{{ o[3] }}">
                                      {{ o[6]|truncate(6, true, '', 0) }}
                                 </div>
-                                <span class="usd-value text-sm italic"></span><span class="text-sm italic">/{{ o[16] }}</span>
-                                    <div class="ratetype text-sm italic"><span class="echange-rates" data-coinname="{{ o[2] }}"> {{ o[6]|truncate(6,true,'',0) }} {{ o[17] }}/{{ o[16] }}</span>
+                                <span class="usd-value"></span><span class="text-sm italic">/{{ o[16] }}</span>
+                                    <div class="ratetype"><span class="echange-rates" data-coinname="{{ o[2] }}"> {{ o[6]|truncate(6,true,'',0) }} {{ o[17] }}/{{ o[16] }}</span>
                                 </div>
                             </td>
                             <!-- RATE -->
 
                             <!-- PERCENTAGE -->
-                            <td class="py-3 px-2 text-xs text-center items-center rate-table-info">
+                            <td class="py-3 px-2 bold text-sm text-center items-center rate-table-info">
                                 <span class="profit-value hidden"></span>
-                                <div class="profittype pt-1"><span class="profit-loss bold text-sm"</span>
+                                <div class="profittype pt-1"><span class="profit-loss"</span>
                                    <div class="coinname-value hidden" data-coinname="{{ o[3] }}">
                                      {{ o[6]|truncate(6, true, '', 0) }}
                                    </div>

--- a/basicswap/templates/settings.html
+++ b/basicswap/templates/settings.html
@@ -195,10 +195,10 @@
                   <path d="M11.3333 6.1133C11.2084 5.98913 11.0395 5.91943 10.8633 5.91943C10.6872 5.91943 10.5182 5.98913 10.3933 6.1133L8.00001 8.47329L5.64001 6.1133C5.5151 5.98913 5.34613 5.91943 5.17001 5.91943C4.99388 5.91943 4.82491 5.98913 4.70001 6.1133C4.63752 6.17527 4.58792 6.249 4.55408 6.33024C4.52023 6.41148 4.50281 6.49862 4.50281 6.58663C4.50281 6.67464 4.52023 6.76177 4.55408 6.84301C4.58792 6.92425 4.63752 6.99799 4.70001 7.05996L7.52667 9.88663C7.58865 9.94911 7.66238 9.99871 7.74362 10.0326C7.82486 10.0664 7.912 10.0838 8.00001 10.0838C8.08801 10.0838 8.17515 10.0664 8.25639 10.0326C8.33763 9.99871 8.41136 9.94911 8.47334 9.88663L11.3333 7.05996C11.3958 6.99799 11.4454 6.92425 11.4793 6.84301C11.5131 6.76177 11.5305 6.67464 11.5305 6.58663C11.5305 6.49862 11.5131 6.41148 11.4793 6.33024C11.4454 6.249 11.3958 6.17527 11.3333 6.1133Z" fill="#8896AB"></path>
                  </svg>
                  <select class="hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none pr-10 dark:bg-gray-500 dark:text-white border border-gray-300 dark:border-gray-400 dark:text-gray-50 dark:placeholder-gray-400 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 focus:ring-0" name="fee_priority_{{ c.name }}">
-                  <option value="0" {% if c.fee_priority==0 %} selected{% endif %}>Default</option>
-                  <option value="1" {% if c.fee_priority==1 %} selected{% endif %}>Low</option>
-                  <option value="2" {% if c.fee_priority==2 %} selected{% endif %}>Medium</option>
-                  <option value="3" {% if c.fee_priority==3 %} selected{% endif %}>High</option>
+                  <option value="0" {% if c.fee_priority==0 %} selected{% endif %}>[Auto] Slow</option>
+                  <option value="1" {% if c.fee_priority==1 %} selected{% endif %}>Slow</option>
+                  <option value="2" {% if c.fee_priority==2 %} selected{% endif %}>Normal</option>
+                  <option value="3" {% if c.fee_priority==3 %} selected{% endif %}>Fast</option>
                  </select>
                 </div>
                </td>


### PR DESCRIPTION
Changed fee to priority 2 (normal), which is adequate for 1-2 block inclusion. 

Monero is designed to auto(0) select between fee lvl 1 and 2 depending on backlog. Due to a bug in monero wallet software, its not auto elevating. 

Monero is releasing a fix in the coming days. 

Will revert these changes when
1. Spam stops or 
2. Monero has released the fix and bsx users have had time to update

@tecnovert please check that i make the changes properly 